### PR TITLE
Read file like objects

### DIFF
--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -14,16 +14,9 @@ from rdkit import Chem
 from rdkit.Chem.SaltRemover import SaltRemover
 
 
-def read_mols(filename, mol_format=None, remove_salts=True):
+def read_mols_from_file(filename, mol_format=None, remove_salts=True):
     """
-    Read molecules. Supports SDF or SMILES format.
-
-    Molecule conformers are combined into a single molecule. Two molecules
-    are considered conformers of the same molecule if they:
-    * Are contiguous in the file
-    * Have identical SMILES strings
-    * Have identical compound names (a warning is issued if compounds lack
-        names)
+    Read molecules from a file.
 
     Parameters
     ----------
@@ -55,6 +48,35 @@ def read_mols(filename, mol_format=None, remove_salts=True):
         f = gzip.open(filename)
     else:
         f = open(filename)
+    mols = read_mols(f, mol_format=mol_format, remove_salts=remove_salts)
+    f.close()
+    return mols
+
+
+def read_mols(f, mol_format, remove_salts=True):
+    """
+    Read molecules. Supports SDF or SMILES format.
+
+    Molecule conformers are combined into a single molecule. Two molecules
+    are considered conformers of the same molecule if they:
+    * Are contiguous in the file
+    * Have identical SMILES strings
+    * Have identical compound names (a warning is issued if compounds lack
+        names)
+
+    Parameters
+    ----------
+    f : file
+        File-like object.
+    mol_format : str, optional
+        Molecule file format. Currently supports 'sdf' and 'smi'.
+    remove_salts : bool, optional (default True)
+        Whether to remove salts.
+
+    Returns
+    -------
+    An ndarray containing Mol objects.
+    """
 
     # read molecules
     mols = []
@@ -73,7 +95,6 @@ def read_mols(filename, mol_format=None, remove_salts=True):
             if name is not None:
                 mol.SetProp('_Name', name)
             mols.append(mol)
-    f.close()
 
     # remove salts
     if remove_salts:

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -3,14 +3,14 @@ Tests for conformers.py.
 """
 from rdkit import Chem
 
-from pande_gas.utils import rdkit_utils as rd
+from rdkit_utils import conformers
 
 
 def test_generate_conformers():
     """Generate molecule conformers."""
     mol = Chem.MolFromSmiles(test_smiles.split()[0])
     assert mol.GetNumConformers() == 0
-    mol = rd.generate_conformers(mol)
+    mol = conformers.generate_conformers(mol)
     assert mol.GetNumConformers() > 0
 
 test_sdf = """aspirin


### PR DESCRIPTION
Changes:
- Add read_mols_from_file method to read mols from filenames. This method supports gzipped files and attempts to extract the mol_format from the filename.
- Update read_mols so it operates on file-like objects. The mol_format argument is now required, since it cannot necessarily be determined from the file-like object.
- Update tests and fix improper imports in test files.
