### PR TITLE
Handle errors

### DIFF
--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -107,6 +107,11 @@ class MolReader(object):
         while True:
             try:
                 new = source.next()
+
+                # skip errors
+                if new is None:
+                    mol_smiles = None
+                    continue
             except StopIteration:
                 break
             if new.HasProp("_Name"):
@@ -115,6 +120,7 @@ class MolReader(object):
                 new_name = None
             new_smiles = Chem.MolToSmiles(new, isomericSmiles=True,
                                           canonical=True)
+            assert new_smiles
             if new_smiles == mol_smiles and new_name == mol_name:
                 if not new_name:
                     warnings.warn("Grouping conformers of an unnamed " +

--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -108,7 +108,7 @@ class MolReader(object):
             try:
                 new = source.next()
 
-                # skip errors
+                # on error, skip and move to the next multiconformer mol
                 if new is None:
                     mol_smiles = None
                     continue


### PR DESCRIPTION
If the RDKit encounters an error during molecule reading, it will return None for that molecule. This PR checks for None during reading and skips that molecule, allowing reading to continue. If None is encountered, the conformer grouping process also moves to a new multiconformer molecule.
