### PR TITLE
Add code analysis to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ before_install:
  - make -j2
  - make install
 
- # Install pep8
+ # Install code analysis tools
  - pip install pep8
+ - pip install pyflakes
 
 install:
  - cd $clone
@@ -35,3 +36,4 @@ install:
 script:
  - nosetests
  - pep8 rdkit_utils
+ - pyflakes rdkit_utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
  - mkdir $RDBASE/External/java_lib
  - cp /usr/share/java/junit.jar $RDBASE/External/java_lib
  - ls -l $RDBASE/External/java_lib
- - cmake ..
+ - cmake -D RDK_BUILD_CPP_TESTS=OFF ..
  - make -j2
  - make install
 
@@ -34,4 +34,4 @@ install:
 
 script:
  - nosetests
- - find ./ -name "*.py" -exec pep8 -v --count {} \;
+ - pep8 rdkit_utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
-  - "2.7"
+ - "2.7"
 
 before_install:
+
  # Install RDKit from source (Release_2014_03_1)
  # Follow the pattern in rdkit/.travis.yml on GitHub
  - clone=`pwd`
@@ -24,9 +25,13 @@ before_install:
  - make -j2
  - make install
 
+ # Install pep8
+ - pip install pep8
+
 install:
  - cd $clone
  - python setup.py install
 
 script:
  - nosetests
+ - find ./ -name "*.py" -exec pep8 -v --count {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_install:
  # Install RDKit from source (Release_2014_03_1)
  # Follow the pattern in rdkit/.travis.yml on GitHub
  - clone=`pwd`
- - cd ~
  - sudo apt-get update -qq
  - sudo apt-get install -qq flex bison build-essential python-numpy cmake python-dev sqlite3 libsqlite3-dev libboost-dev libboost-python-dev libboost-regex-dev python-imaging openjdk-7-jdk swig junit
- - wget https://github.com/rdkit/rdkit/archive/Release_2014_03_1.tar.gz
- - tar -xzf Release_2014_03_1.tar.gz
- - cd rdkit-Release_2014_03_1/
+ - cd ~
+ - git clone https://github.com/rdkit/rdkit.git rdkit/rdkit
+ - cd rdkit/rdkit
+ - git checkout tags/Release_2014_03_1
  - export RDBASE=`pwd`
  - export PYTHONPATH=${PYTHONPATH}:${RDBASE}
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${RDBASE}/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ before_install:
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${RDBASE}/lib
  - mkdir build
  - cd build
- - mkdir $RDBASE/External/java_lib
- - cp /usr/share/java/junit.jar $RDBASE/External/java_lib
- - ls -l $RDBASE/External/java_lib
  - cmake -D RDK_BUILD_CPP_TESTS=OFF ..
  - make -j2
  - make install

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -71,7 +71,7 @@ def test_read_multiconformer():
     _, filename = tempfile.mkstemp(suffix='.sdf')
     serial.write_mols_to_file([mol], filename)
     mols = serial.read_mols_from_file(filename)
-    mols = [mol for mol in mols]
+    mols = [m for m in mols]
     assert len(mols) == 1
     assert mols[0].GetNumConformers() == mol.GetNumConformers()
     os.remove(filename)


### PR DESCRIPTION
Add pep8 and pyflakes code checking. Also turn off building of RDKit tests (which are not used) to speed up the build.
