### PR TITLE
Add group_conformers argument to MolReader

### DIFF
--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -78,7 +78,7 @@ def test_read_multiconformer():
 
 
 def test_read_disabled_conformers():
-    """Read multiconformer SDF file with group_confomers=False."""
+    """Read multiconformer SDF file with group_conformers=False."""
     mol = Chem.MolFromMolBlock(aspirin_sdf)
     mol = conformers.generate_conformers(mol, n_conformers=2)
     assert mol.GetNumConformers() > 1

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -77,6 +77,21 @@ def test_read_multiconformer():
     os.remove(filename)
 
 
+def test_read_disabled_conformers():
+    """Read multiconformer SDF file with group_confomers=False."""
+    mol = Chem.MolFromMolBlock(aspirin_sdf)
+    mol = conformers.generate_conformers(mol, n_conformers=2)
+    assert mol.GetNumConformers() > 1
+    _, filename = tempfile.mkstemp(suffix='.sdf')
+    serial.write_mols_to_file([mol], filename)
+    mols = serial.read_mols_from_file(filename, group_conformers=False)
+    mols = [m for m in mols]
+    assert len(mols) == 2
+    for m in mols:
+        assert m.GetNumConformers() == 1
+    os.remove(filename)
+
+
 def test_read_multiple_smiles():
     """Read multiple SMILES file."""
     _, filename = tempfile.mkstemp(suffix='.smi')


### PR DESCRIPTION
Make grouping of conformers optional, as specified by a new group_conformers argument to the MolReader class.
