### PR TITLE
Generate a pool of conformers

### DIFF
--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -35,7 +35,7 @@ def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
         no pruning is performed.
     force_field : str, optional (default 'uff')
         Force field to use for conformer energy minimization. Options are
-        'uff' and 'mmff'.
+        'uff', 'mmff94', and 'mmff94s'.
     prune_after_minimization : bool, optional (default True)
         Whether to prune conformers by RMSD after minimization.
     pool_multiplier : int, optional (default 10)
@@ -55,13 +55,15 @@ def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
 
     # minimize conformers and get energies
     energy = np.zeros(cids.size, dtype=float)
-    if force_field == 'mmff':
+    if force_field.startswith('mmff'):
         AllChem.MMFFSanitizeMolecule(mol)
+        mmff_props = AllChem.MMFFGetMoleculeProperties(mol, force_field)
     for i, cid in enumerate(cids):
         if force_field == 'uff':
             ff = AllChem.UFFGetMoleculeForceField(mol, confId=int(cid))
-        elif force_field == 'mmff':
-            ff = AllChem.MMFFGetMoleculeForceField(mol, confId=int(cid))
+        elif force_field.startswith('mmff'):
+            ff = AllChem.MMFFGetMoleculeForceField(
+                mol, mmff_props, confId=int(cid))
         else:
             raise ValueError("Invalid force_field '{}'.".format(force_field))
         ff.Minimize()

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -13,6 +13,22 @@ def test_generate_conformers():
     mol = conformers.generate_conformers(mol)
     assert mol.GetNumConformers() > 0
 
+
+def test_mmff94_minimization():
+    """Generate conformers and minimize with MMFF94."""
+    mol = Chem.MolFromSmiles(test_smiles.split()[0])
+    assert mol.GetNumConformers() == 0
+    mol = conformers.generate_conformers(mol, force_field='mmff94')
+    assert mol.GetNumConformers() > 0
+
+
+def test_mmff94s_minimization():
+    """Generate conformers and minimize with MMFF94s."""
+    mol = Chem.MolFromSmiles(test_smiles.split()[0])
+    assert mol.GetNumConformers() == 0
+    mol = conformers.generate_conformers(mol, force_field='mmff94s')
+    assert mol.GetNumConformers() > 0
+
 test_sdf = """aspirin
      RDKit
 


### PR DESCRIPTION
Fix for #8. Generates a pool of conformers and selects from that pool. Pruning by RMSD is performed twice: once during the call to EmbedMultipleConfs to generate the initial pool, and again (optionally) after minimization of the conformers.

The expense associated with generating the initial pool can be modulated using the `pool_multiplier` argument, which defaults to 10x the number of requested conformers.
