### PR TITLE
Object-oriented conformer generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
  # Follow the pattern in rdkit/.travis.yml on GitHub
  - clone=`pwd`
  - sudo apt-get update -qq
- - sudo apt-get install -qq flex bison build-essential python-numpy python-scipy cmake python-dev sqlite3 libsqlite3-dev libboost-dev libboost-python-dev libboost-regex-dev python-imaging openjdk-7-jdk swig junit
+ - sudo apt-get install -qq flex bison build-essential python-numpy cmake python-dev sqlite3 libsqlite3-dev libboost-dev libboost-python-dev libboost-regex-dev python-imaging openjdk-7-jdk swig junit
  - cd ~
  - git clone https://github.com/rdkit/rdkit.git rdkit/rdkit
  - cd rdkit/rdkit

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
  # Follow the pattern in rdkit/.travis.yml on GitHub
  - clone=`pwd`
  - sudo apt-get update -qq
- - sudo apt-get install -qq flex bison build-essential python-numpy cmake python-dev sqlite3 libsqlite3-dev libboost-dev libboost-python-dev libboost-regex-dev python-imaging openjdk-7-jdk swig junit
+ - sudo apt-get install -qq flex bison build-essential python-numpy python-scipy cmake python-dev sqlite3 libsqlite3-dev libboost-dev libboost-python-dev libboost-regex-dev python-imaging openjdk-7-jdk swig junit
  - cd ~
  - git clone https://github.com/rdkit/rdkit.git rdkit/rdkit
  - cd rdkit/rdkit

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -213,14 +213,12 @@ class ConformerGenerator(object):
             mol.RemoveConformer(conf_ids[i])
 
         # update conformer IDs and ordering
-        confs = []
+        new = Chem.Mol(mol)
+        new.RemoveAllConformers()
         for i in keep:
             conf = mol.GetConformer(conf_ids[i])
-            confs.append(conf)
-        mol.RemoveAllConformers()
-        for i, conf in enumerate(confs):
-            mol.AddConformer(conf, assignId=True)
-        return mol
+            new.AddConformer(conf, assignId=True)
+        return new
 
     @staticmethod
     def get_conformer_rmsd(mol):

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -22,6 +22,9 @@ class ConformerGenerator(object):
     2. Minimize conformers.
     3. Prune conformers using an RMSD threshold.
 
+    Note that pruning is done _after_ minimization, which differs from the
+    protocol described in the references.
+
     References
     ----------
     * http://rdkit.org/docs/GettingStartedInPython.html

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -188,7 +188,7 @@ class ConformerGenerator(object):
         discard : array_like
             Indices of conformers to discard.
         """
-        if self.rmsd_threshold is None or self.rmsd_threshold < 0:
+        if self.rmsd_threshold < 0:
             return range(len(energies)), []
         if len(energies) == 1:
             return [0], []

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -24,7 +24,7 @@ class ConformerGenerator(object):
 
     Parameters
     ----------
-    n_conformers : int, optional (default 1)
+    max_conformers : int, optional (default 1)
         Maximum number of conformers to generate (after pruning).
     rmsd_threshold : float, optional (default 0.5)
         RMSD threshold for pruning conformers. If None or negative, no
@@ -36,14 +36,14 @@ class ConformerGenerator(object):
         Whether to prune conformers by RMSD after minimization. If False,
         pool_multiplier is set to 1.
     pool_multiplier : int, optional (default 10)
-        Factor to multiply by n_conformers to generate the initial
+        Factor to multiply by max_conformers to generate the initial
         conformer pool. Since conformers are pruned after energy
         minimization, increasing the size of the pool increases the chance
-        of identifying n_conformers unique conformers.
+        of identifying max_conformers unique conformers.
     """
-    def __init__(self, n_conformers=1, rmsd_threshold=0.5, force_field='uff',
+    def __init__(self, max_conformers=1, rmsd_threshold=0.5, force_field='uff',
                  prune_after_minimization=True, pool_multiplier=10):
-        self.n_conformers = n_conformers
+        self.max_conformers = max_conformers
         if rmsd_threshold is None or rmsd_threshold < 0:
             rmsd_threshold = -1.
         self.rmsd_threshold = rmsd_threshold
@@ -102,7 +102,7 @@ class ConformerGenerator(object):
         """
         mol = Chem.AddHs(mol)
         AllChem.EmbedMultipleConfs(
-            mol, numConfs=self.n_conformers * self.pool_multiplier,
+            mol, numConfs=self.max_conformers * self.pool_multiplier,
             pruneRmsThresh=self.rmsd_threshold)
         return mol
 
@@ -193,8 +193,8 @@ class ConformerGenerator(object):
                 keep.append(i)
                 continue
 
-            # discard conformers after n_conformers is reached
-            if len(keep) >= self.n_conformers:
+            # discard conformers after max_conformers is reached
+            if len(keep) >= self.max_conformers:
                 discard.append(i)
                 continue
 

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -13,8 +13,7 @@ from rdkit.Chem import AllChem
 
 
 def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
-                        force_field='uff', prune_after_minimization=True,
-                        pool_multiplier=10):
+                        force_field='uff', pool_multiplier=10):
     """
     Generate molecule conformers. See:
     * http://rdkit.org/docs/GettingStartedInPython.html
@@ -36,8 +35,6 @@ def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
     force_field : str, optional (default 'uff')
         Force field to use for conformer energy minimization. Options are
         'uff', 'mmff94', and 'mmff94s'.
-    prune_after_minimization : bool, optional (default True)
-        Whether to prune conformers by RMSD after minimization.
     pool_multiplier : int, optional (default 10)
         Factor to multiply by n_conformers to generate the initial
         conformer pool. Since conformers are pruned after energy
@@ -68,8 +65,6 @@ def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
             raise ValueError("Invalid force_field '{}'.".format(force_field))
         ff.Minimize()
         energy[i] = ff.CalcEnergy()
-    if not prune_after_minimization:
-        return mol
 
     # calculate RMSD between minimized conformers
     rmsd = np.zeros((cids.size, cids.size), dtype=float)

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -240,3 +240,18 @@ class ConformerGenerator(object):
                                                 fit_conf.GetId())
                 rmsd[j, i] = rmsd[i, j]
         return rmsd
+
+
+def generate_conformers(mol, **kwargs):
+    """
+    Generate molecule conformers.
+
+    Parameters
+    ----------
+    mol : RDKit Mol
+        Molecule.
+    kwargs : dict, optional
+        Keyword arguments for ConformerGenerator.
+    """
+    engine = ConformerGenerator(**kwargs)
+    return engine(mol)

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -240,18 +240,3 @@ class ConformerGenerator(object):
                                                 fit_conf.GetId())
                 rmsd[j, i] = rmsd[i, j]
         return rmsd
-
-
-def generate_conformers(mol, **kwargs):
-    """
-    Generate molecule conformers.
-
-    Parameters
-    ----------
-    mol : RDKit Mol
-        Molecule.
-    kwargs : dict, optional
-        Keyword arguments for ConformerGenerator.
-    """
-    engine = ConformerGenerator(**kwargs)
-    return engine(mol)

--- a/rdkit_utils/conformers.py
+++ b/rdkit_utils/conformers.py
@@ -12,27 +12,23 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 
-def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
-                        force_field='uff', prune_after_minimization=True,
-                        pool_multiplier=10):
+class ConformerGenerator(object):
     """
-    Generate molecule conformers. See:
+    Generate molecule conformers.
+
+    References
+    ----------
     * http://rdkit.org/docs/GettingStartedInPython.html
       #working-with-3d-molecules
     * http://pubs.acs.org/doi/full/10.1021/ci2004658
 
-    This function returns a copy of the molecule, created before adding
-    hydrogens.
-
     Parameters
     ----------
-    mol : RDKit Mol
-        Molecule.
     n_conformers : int, optional (default 1)
         Maximum number of conformers to generate (after pruning).
     rmsd_threshold : float, optional (default 0.5)
-        RMSD threshold for distinguishing conformers. If None or negative,
-        no pruning is performed.
+        RMSD threshold for pruning conformers. If None or negative, no
+        pruning is performed.
     force_field : str, optional (default 'uff')
         Force field to use for conformer energy minimization. Options are
         'uff', 'mmff94', and 'mmff94s'.
@@ -45,83 +41,184 @@ def generate_conformers(mol, n_conformers=1, rmsd_threshold=0.5,
         minimization, increasing the size of the pool increases the chance
         of identifying n_conformers unique conformers.
     """
-    if rmsd_threshold is None or rmsd_threshold < 0:
-        rmsd_threshold = -1.
-    mol = Chem.AddHs(mol)
-    if not prune_after_minimization:
-        pool_multiplier = 1
-    cids = AllChem.EmbedMultipleConfs(
-        mol, numConfs=n_conformers * pool_multiplier,
-        pruneRmsThresh=rmsd_threshold)
-    assert mol.GetNumConformers() >= 1
-    cids = np.asarray(cids, dtype=int)
+    def __init__(self, n_conformers=1, rmsd_threshold=0.5, force_field='uff',
+                 prune_after_minimization=True, pool_multiplier=10):
+        self.n_conformers = n_conformers
+        if rmsd_threshold is None or rmsd_threshold < 0:
+            rmsd_threshold = -1.
+        self.rmsd_threshold = rmsd_threshold
+        self.force_field = force_field
+        self.prune_after_minimization = prune_after_minimization
+        if not prune_after_minimization:
+            pool_multiplier = 1
+        self.pool_multiplier = pool_multiplier
 
-    # minimize conformers and get energies
-    energy = np.zeros(cids.size, dtype=float)
-    if force_field.startswith('mmff'):
-        AllChem.MMFFSanitizeMolecule(mol)
-        mmff_props = AllChem.MMFFGetMoleculeProperties(mol, force_field)
-    for i, cid in enumerate(cids):
-        if force_field == 'uff':
-            ff = AllChem.UFFGetMoleculeForceField(mol, confId=int(cid))
-        elif force_field.startswith('mmff'):
-            ff = AllChem.MMFFGetMoleculeForceField(
-                mol, mmff_props, confId=int(cid))
-        else:
-            raise ValueError("Invalid force_field '{}'.".format(force_field))
-        ff.Minimize()
-        energy[i] = ff.CalcEnergy()
-    if not prune_after_minimization:
+    def __call__(self, mol):
+        """
+        Generate conformers for a molecule.
+
+        Parameters
+        ----------
+        mol : RDKit Mol
+            Molecule.
+        """
+        return self.generate_conformers(mol)
+
+    def generate_conformers(self, mol):
+        """
+        Generate conformers for a molecule.
+
+        This function returns a copy of the original molecule with embedded
+        conformers.
+
+        Parameters
+        ----------
+        mol : RDKit Mol
+            Molecule.
+        """
+        mol = self.embed_molecule(mol)
+        energies = self.minimize_conformers(mol)
+        if not self.prune_after_minimization:
+            return mol
+        mol = self.prune_conformers(mol, energies)
         return mol
 
-    # calculate RMSD between minimized conformers
-    rmsd = np.zeros((cids.size, cids.size), dtype=float)
-    for i in xrange(cids.size):
-        for j in xrange(cids.size):
-            if i >= j:
+    def embed_molecule(self, mol):
+        """
+        Generate initial conformer pool.
+
+        Parameters
+        ----------
+        mol : RDKit Mol
+            Molecule.
+        """
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMultipleConfs(
+            mol, numConfs=self.n_conformers * self.pool_multiplier,
+            pruneRmsThresh=self.rmsd_threshold)
+        assert mol.GetNumConformers() >= 1
+        return mol
+
+    def minimize_conformers(self, mol):
+        """
+        Minimize molecule conformers.
+
+        Parameters
+        ----------
+        mol : RDKit Mol
+            Molecule.
+
+        Returns
+        -------
+        energies : array_like
+            Minimized conformer energies.
+        """
+        energies = np.zeros(mol.GetNumConformers(), dtype=float)
+        if self.force_field.startswith('mmff'):
+            AllChem.MMFFSanitizeMolecule(mol)
+            mmff_props = AllChem.MMFFGetMoleculeProperties(mol,
+                                                           self.force_field)
+        for i, conf in enumerate(mol.GetConformers()):
+            if self.force_field == 'uff':
+                ff = AllChem.UFFGetMoleculeForceField(mol, confId=conf.GetId())
+            elif self.force_field.startswith('mmff'):
+                ff = AllChem.MMFFGetMoleculeForceField(
+                    mol, mmff_props, confId=conf.GetId())
+            else:
+                raise ValueError("Invalid force_field " +
+                                 "'{}'.".format(self.force_field))
+            ff.Minimize()
+            energies[i] = ff.CalcEnergy()
+        return energies
+
+    def prune_conformers(self, mol, energies):
+        """
+        Prune conformers from a molecule using an RMSD threshold.
+
+        Parameters
+        ----------
+        mol : RDKit Mol
+            Molecule.
+        energies : array_like
+            Minimized conformer energies.
+        """
+        rmsd = self.get_conformer_rmsd(mol)
+        _, discard = self.select_conformers(energies, rmsd)
+        conf_ids = [conf.GetId() for conf in mol.GetConformers()]
+        for i in discard:
+            mol.RemoveConformer(conf_ids[i])
+        return mol
+
+    @staticmethod
+    def get_conformer_rmsd(mol):
+        """
+        Calculate conformer-conformer RMSD.
+
+        Parameters
+        ----------
+        mol : RDKit Mol
+            Molecule.
+        """
+        rmsd = np.zeros((mol.GetNumConformers(), mol.GetNumConformers()),
+                        dtype=float)
+        for i, ref_conf in enumerate(mol.GetConformers()):
+            for j, fit_conf in enumerate(mol.GetConformers()):
+                if i >= j:
+                    continue
+                rmsd[i, j] = AllChem.GetBestRMS(mol, mol, ref_conf.GetId(),
+                                                fit_conf.GetId())
+                rmsd[j, i] = rmsd[i, j]
+        return rmsd
+
+    def select_conformers(self, energies, rmsd):
+        """
+        Select diverse conformers starting with lowest energy.
+
+        Parameters
+        ----------
+        energies : array_like
+            Conformer energies.
+        rmsd : ndarray
+            Conformer-conformer RMSD.
+
+        Returns
+        -------
+        keep : array_like
+            Indices of conformers to keep.
+        discard : array_like
+            Indices of conformers to discard.
+        """
+        if self.rmsd_threshold is None or self.rmsd_threshold < 0:
+            return range(len(energies)), []
+        if len(energies) == 1:
+            return [0], []
+        sort = np.argsort(energies)
+        keep = [sort[0]]  # always keep lowest-energy conformer
+        discard = []
+        for i in sort[1:]:
+            if len(keep) >= self.n_conformers:
+                discard.append(i)
                 continue
-            rmsd[i, j] = AllChem.GetBestRMS(mol, mol, cids[i], cids[j])
-            rmsd[j, i] = rmsd[i, j]
+            this_rmsd = rmsd[i][np.asarray(keep, dtype=int)]
+            if np.all(this_rmsd >= self.rmsd_threshold):
+                keep.append(i)
+            else:
+                discard.append(i)
+        keep = np.asarray(keep, dtype=int)
+        discard = np.asarray(discard, dtype=int)
+        return keep, discard
 
-    # discard conformers within RMSD threshold
-    _, discard = choose_conformers(energy, rmsd, n_conformers, rmsd_threshold)
-    for i in discard:
-        mol.RemoveConformer(cids[i])
-    return mol
 
-
-def choose_conformers(energy, rmsd, n_conformers, rmsd_threshold=0.5):
+def generate_conformers(mol, **kwargs):
     """
-    Select diverse conformers starting with lowest energy.
+    Generate molecule conformers.
 
     Parameters
     ----------
-    energy : array_like
-        Conformer energies.
-    rmsd : ndarray
-        Conformer-conformer RMSD values.
-    n_conformers : int
-        Maximum number of conformers to choose.
-    rmsd_threshold : float, optional (default 0.5)
-        RMSD threshold for distinguishing conformers. If None or negative,
-        no pruning is performed.
+    mol : RDKit Mol
+        Molecule.
+    kwargs : dict, optional
+        Keyword arguments for ConformerGenerator.
     """
-    if rmsd_threshold is None or rmsd_threshold < 0:
-        return np.arange(len(energy))
-    if len(energy) == 1:
-        return [0], []
-    sort = np.argsort(energy)
-    keep = [sort[0]]
-    discard = []
-    for i in sort[1:]:
-        if len(keep) >= n_conformers:
-            discard.append(i)
-            continue
-        this_rmsd = rmsd[i][np.asarray(keep, dtype=int)]
-        if np.all(this_rmsd >= rmsd_threshold):
-            keep.append(i)
-        else:
-            discard.append(i)
-    keep = np.asarray(keep, dtype=int)
-    discard = np.asarray(discard, dtype=int)
-    return keep, discard
+    engine = ConformerGenerator(**kwargs)
+    return engine(mol)

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -81,26 +81,11 @@ class TestConformerGenerator(unittest.TestCase):
         # conformers
         assert len(energies) == mol.GetNumConformers()
 
-    def test_prune_conformers_after_minimization(self):
-        """
-        Test conformer pruning after minimization.
-        """
-        engine = conformers.ConformerGenerator(max_conformers=10,
-                                               prune_after_minimization=True)
-        self._pruning_tests(engine)
-
-    def test_prune_conformers_before_minimization(self):
-        """
-        Test conformer pruning before minimization.
-        """
-        engine = conformers.ConformerGenerator(max_conformers=10,
-                                               prune_after_minimization=False)
-        self._pruning_tests(engine)
-
-    def _pruning_tests(self, engine):
+    def test_prune_conformers(self):
         """
         Test ConformerGenerator.prune_conformers.
         """
+        engine = conformers.ConformerGenerator(max_conformers=10)
         mol = engine.embed_molecule(self.mol)
 
         # check that there is more than one conformer

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -1,65 +1,123 @@
 """
 Tests for conformers.py.
 """
+import numpy as np
+from scipy.spatial.distance import is_valid_dm
+import unittest
+
 from rdkit import Chem
 
 from rdkit_utils import conformers
 
 
-def test_generate_conformers():
-    """Generate molecule conformers."""
-    mol = Chem.MolFromSmiles(test_smiles.split()[0])
-    assert mol.GetNumConformers() == 0
-    mol = conformers.generate_conformers(mol)
-    assert mol.GetNumConformers() > 0
+class TestConformerGenerator(unittest.TestCase):
+    """
+    Tests for ConformerGenerator.
+    """
+    def setUp(self):
+        """
+        Set up tests.
+        """
+        mol = Chem.MolFromSmiles(test_smiles.split()[0])
+        assert mol.GetNumConformers() == 0
+        self.mol = mol
 
+    def test_generate_conformers(self):
+        """
+        Generate molecule conformers using default parameters.
+        """
+        mol = conformers.generate_conformers(self.mol)
+        assert mol.GetNumConformers() > 0
 
-def test_mmff94_minimization():
-    """Generate conformers and minimize with MMFF94."""
-    mol = Chem.MolFromSmiles(test_smiles.split()[0])
-    assert mol.GetNumConformers() == 0
-    mol = conformers.generate_conformers(mol, force_field='mmff94')
-    assert mol.GetNumConformers() > 0
+    def test_mmff94_minimization(self):
+        """
+        Generate conformers and minimize with MMFF94 force field.
+        """
+        mol = conformers.generate_conformers(self.mol, force_field='mmff94')
+        assert mol.GetNumConformers() > 0
 
+    def test_mmff94s_minimization(self):
+        """
+        Generate conformers and minimize with MMFF94s force field.
+        """
+        mol = conformers.generate_conformers(self.mol, force_field='mmff94s')
+        assert mol.GetNumConformers() > 0
 
-def test_mmff94s_minimization():
-    """Generate conformers and minimize with MMFF94s."""
-    mol = Chem.MolFromSmiles(test_smiles.split()[0])
-    assert mol.GetNumConformers() == 0
-    mol = conformers.generate_conformers(mol, force_field='mmff94s')
-    assert mol.GetNumConformers() > 0
+    def test_embed_molecule(self):
+        """
+        Test ConformerGenerator.embed_molecule.
+        """
+        engine = conformers.ConformerGenerator()
+        mol = engine.embed_molecule(self.mol)
+        assert mol.GetNumConformers() > 0
 
-test_sdf = """aspirin
-     RDKit
+    def test_minimize_conformers(self):
+        """
+        Test ConformerGenerator.minimize_conformers.
+        """
+        engine = conformers.ConformerGenerator()
+        mol = engine.embed_molecule(self.mol)
+        assert mol.GetNumConformers() > 0
+        start = engine.get_conformer_energies(mol)
+        engine.minimize_conformers(mol)
+        finish = engine.get_conformer_energies(mol)
 
- 13 13  0  0  0  0  0  0  0  0999 V2000
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
-  1  2  1  0
-  2  3  2  0
-  2  4  1  0
-  4  5  1  0
-  5  6  2  0
-  6  7  1  0
-  7  8  2  0
-  8  9  1  0
-  9 10  2  0
- 10 11  1  0
- 11 12  2  0
- 11 13  1  0
- 10  5  1  0
-M  END
-"""
+        # check that all minimized energies are lower
+        assert np.all(start > finish), (start, finish)
+
+    def test_get_conformer_energies(self):
+        """
+        Test ConformerGenerator.get_conformer_energies.
+        """
+        engine = conformers.ConformerGenerator()
+        mol = engine.embed_molecule(self.mol)
+        assert mol.GetNumConformers() > 0
+        energies = engine.get_conformer_energies(mol)
+
+        # check that the number of energies matches the number of
+        # conformers
+        assert len(energies) == mol.GetNumConformers()
+
+    def test_prune_conformers(self):
+        """
+        Test ConformerGenerator.prune_conformers.
+        """
+        engine = conformers.ConformerGenerator(n_conformers=10)
+        mol = engine.embed_molecule(self.mol)
+
+        # check that there is more than one conformer
+        assert mol.GetNumConformers() > 1
+        engine.minimize_conformers(mol)
+        energies = engine.get_conformer_energies(mol)
+        pruned = engine.prune_conformers(mol)
+        pruned_energies = engine.get_conformer_energies(mol)
+
+        # check that the number of conformers has not increased
+        assert pruned.GetNumConformers() <= mol.GetNumConformers()
+
+        # check that lowest energy conformer was selected
+        assert np.allclose(min(energies), min(pruned_energies))
+
+        # check that pruned energies are taken from the original set
+        for energy in pruned_energies:
+            assert np.allclose(min(np.fabs(energies - energy)), 0)
+
+        # check that conformers are in order of increasing energy
+        sort = np.argsort(pruned_energies)
+        assert np.array_equal(sort, np.arange(len(pruned_energies))), sort
+
+    def test_get_conformer_rmsd(self):
+        """
+        Test ConformerGenerator.get_conformer_rmsd.
+        """
+        engine = conformers.ConformerGenerator(n_conformers=10)
+        mol = engine.embed_molecule(self.mol)
+
+        # check that there is more than one conformer
+        assert mol.GetNumConformers() > 1
+        rmsd = engine.get_conformer_rmsd(mol)
+
+        # check for a valid distance matrix
+        assert is_valid_dm(rmsd)
 
 test_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O aspirin'

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -30,6 +30,9 @@ class TestConformerGenerator(unittest.TestCase):
         mol = self.engine.generate_conformers(self.mol)
         assert mol.GetNumConformers() > 0
 
+        # check that molecule names are retained
+        assert self.mol.GetProp('_Name') == mol.GetProp('_Name')
+
     def test_mmff94_minimization(self):
         """
         Generate conformers and minimize with MMFF94 force field.

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -117,7 +117,11 @@ class TestConformerGenerator(unittest.TestCase):
         rmsd = engine.get_conformer_rmsd(mol)
 
         # check for a valid distance matrix
+        assert rmsd.shape[0] == rmsd.shape[1] == mol.GetNumConformers()
         assert np.allclose(np.diag(rmsd), 0)
         assert np.array_equal(rmsd, rmsd.T)
+
+        # check for non-zero off-diagonal values
+        assert np.all(rmsd[np.triu_indices_from(rmsd, k=1)] > 0), rmsd
 
 test_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O aspirin'

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -81,11 +81,26 @@ class TestConformerGenerator(unittest.TestCase):
         # conformers
         assert len(energies) == mol.GetNumConformers()
 
-    def test_prune_conformers(self):
+    def test_prune_conformers_after_minimization(self):
+        """
+        Test conformer pruning after minimization.
+        """
+        engine = conformers.ConformerGenerator(max_conformers=10,
+                                               prune_after_minimization=True)
+        self._pruning_tests(engine)
+
+    def test_prune_conformers_before_minimization(self):
+        """
+        Test conformer pruning before minimization.
+        """
+        engine = conformers.ConformerGenerator(max_conformers=10,
+                                               prune_after_minimization=False)
+        self._pruning_tests(engine)
+
+    def _pruning_tests(self, engine):
         """
         Test ConformerGenerator.prune_conformers.
         """
-        engine = conformers.ConformerGenerator(max_conformers=10)
         mol = engine.embed_molecule(self.mol)
 
         # check that there is more than one conformer
@@ -94,6 +109,9 @@ class TestConformerGenerator(unittest.TestCase):
         energies = engine.get_conformer_energies(mol)
         pruned = engine.prune_conformers(mol)
         pruned_energies = engine.get_conformer_energies(pruned)
+
+        # check that the number of conformers is not to large
+        assert pruned.GetNumConformers() <= engine.max_conformers
 
         # check that the number of conformers has not increased
         assert pruned.GetNumConformers() <= mol.GetNumConformers()

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -25,21 +25,24 @@ class TestConformerGenerator(unittest.TestCase):
         """
         Generate molecule conformers using default parameters.
         """
-        mol = conformers.generate_conformers(self.mol)
+        engine = conformers.ConformerGenerator()
+        mol = engine.generate_conformers(self.mol)
         assert mol.GetNumConformers() > 0
 
     def test_mmff94_minimization(self):
         """
         Generate conformers and minimize with MMFF94 force field.
         """
-        mol = conformers.generate_conformers(self.mol, force_field='mmff94')
+        engine = conformers.ConformerGenerator(force_field='mmff94')
+        mol = engine.generate_conformers(self.mol)
         assert mol.GetNumConformers() > 0
 
     def test_mmff94s_minimization(self):
         """
         Generate conformers and minimize with MMFF94s force field.
         """
-        mol = conformers.generate_conformers(self.mol, force_field='mmff94s')
+        engine = conformers.ConformerGenerator(force_field='mmff94s')
+        mol = engine.generate_conformers(self.mol)
         assert mol.GetNumConformers() > 0
 
     def test_embed_molecule(self):

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -20,13 +20,13 @@ class TestConformerGenerator(unittest.TestCase):
         mol = Chem.MolFromSmiles(test_smiles.split()[0])
         assert mol.GetNumConformers() == 0
         self.mol = mol
+        self.engine = conformers.ConformerGenerator()
 
     def test_generate_conformers(self):
         """
         Generate molecule conformers using default parameters.
         """
-        engine = conformers.ConformerGenerator()
-        mol = engine.generate_conformers(self.mol)
+        mol = self.engine.generate_conformers(self.mol)
         assert mol.GetNumConformers() > 0
 
     def test_mmff94_minimization(self):
@@ -49,20 +49,18 @@ class TestConformerGenerator(unittest.TestCase):
         """
         Test ConformerGenerator.embed_molecule.
         """
-        engine = conformers.ConformerGenerator()
-        mol = engine.embed_molecule(self.mol)
+        mol = self.engine.embed_molecule(self.mol)
         assert mol.GetNumConformers() > 0
 
     def test_minimize_conformers(self):
         """
         Test ConformerGenerator.minimize_conformers.
         """
-        engine = conformers.ConformerGenerator()
-        mol = engine.embed_molecule(self.mol)
+        mol = self.engine.embed_molecule(self.mol)
         assert mol.GetNumConformers() > 0
-        start = engine.get_conformer_energies(mol)
-        engine.minimize_conformers(mol)
-        finish = engine.get_conformer_energies(mol)
+        start = self.engine.get_conformer_energies(mol)
+        self.engine.minimize_conformers(mol)
+        finish = self.engine.get_conformer_energies(mol)
 
         # check that all minimized energies are lower
         assert np.all(start > finish), (start, finish)
@@ -71,10 +69,9 @@ class TestConformerGenerator(unittest.TestCase):
         """
         Test ConformerGenerator.get_conformer_energies.
         """
-        engine = conformers.ConformerGenerator()
-        mol = engine.embed_molecule(self.mol)
+        mol = self.engine.embed_molecule(self.mol)
         assert mol.GetNumConformers() > 0
-        energies = engine.get_conformer_energies(mol)
+        energies = self.engine.get_conformer_energies(mol)
 
         # check that the number of energies matches the number of
         # conformers

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -2,7 +2,6 @@
 Tests for conformers.py.
 """
 import numpy as np
-from scipy.spatial.distance import is_valid_dm
 import unittest
 
 from rdkit import Chem
@@ -118,6 +117,7 @@ class TestConformerGenerator(unittest.TestCase):
         rmsd = engine.get_conformer_rmsd(mol)
 
         # check for a valid distance matrix
-        assert is_valid_dm(rmsd)
+        assert np.allclose(np.diag(rmsd), 0)
+        assert np.array_equal(rmsd, rmsd.T)
 
 test_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O aspirin'

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -17,9 +17,10 @@ class TestConformerGenerator(unittest.TestCase):
         """
         Set up tests.
         """
-        mol = Chem.MolFromSmiles(test_smiles.split()[0])
-        assert mol.GetNumConformers() == 0
-        self.mol = mol
+        aspirin_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O aspirin'
+        self.mol = Chem.MolFromSmiles(aspirin_smiles.split()[0])
+        self.mol.SetProp('_Name', 'aspirin')
+        assert self.mol.GetNumConformers() == 0
         self.engine = conformers.ConformerGenerator()
 
     def test_generate_conformers(self):
@@ -123,5 +124,3 @@ class TestConformerGenerator(unittest.TestCase):
 
         # check for non-zero off-diagonal values
         assert np.all(rmsd[np.triu_indices_from(rmsd, k=1)] > 0), rmsd
-
-test_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O aspirin'

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -84,7 +84,7 @@ class TestConformerGenerator(unittest.TestCase):
         """
         Test ConformerGenerator.prune_conformers.
         """
-        engine = conformers.ConformerGenerator(n_conformers=10)
+        engine = conformers.ConformerGenerator(max_conformers=10)
         mol = engine.embed_molecule(self.mol)
 
         # check that there is more than one conformer
@@ -112,7 +112,7 @@ class TestConformerGenerator(unittest.TestCase):
         """
         Test ConformerGenerator.get_conformer_rmsd.
         """
-        engine = conformers.ConformerGenerator(n_conformers=10)
+        engine = conformers.ConformerGenerator(max_conformers=10)
         mol = engine.embed_molecule(self.mol)
 
         # check that there is more than one conformer

--- a/rdkit_utils/tests/test_conformers.py
+++ b/rdkit_utils/tests/test_conformers.py
@@ -90,7 +90,7 @@ class TestConformerGenerator(unittest.TestCase):
         engine.minimize_conformers(mol)
         energies = engine.get_conformer_energies(mol)
         pruned = engine.prune_conformers(mol)
-        pruned_energies = engine.get_conformer_energies(mol)
+        pruned_energies = engine.get_conformer_energies(pruned)
 
         # check that the number of conformers has not increased
         assert pruned.GetNumConformers() <= mol.GetNumConformers()

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -66,7 +66,7 @@ def test_read_file_like():
 def test_read_multiconformer():
     """Read multiconformer SDF file."""
     mol = Chem.MolFromMolBlock(aspirin_sdf)
-    mol = conformers.generate_conformers(mol, n_conformers=2)
+    mol = conformers.generate_conformers(mol, max_conformers=2)
     assert mol.GetNumConformers() > 1
     _, filename = tempfile.mkstemp(suffix='.sdf')
     serial.write_mols_to_file([mol], filename)
@@ -94,9 +94,9 @@ def test_read_multiple_smiles():
 def test_read_multiple_multiconformer():
     """Read multiple multiconformer SDF file."""
     mol1 = Chem.MolFromSmiles(aspirin_smiles.split()[0])
-    mol1 = conformers.generate_conformers(mol1, n_conformers=2)
+    mol1 = conformers.generate_conformers(mol1, max_conformers=2)
     mol2 = Chem.MolFromSmiles(ibuprofen_smiles.split()[0])
-    mol2 = conformers.generate_conformers(mol2, n_conformers=2)
+    mol2 = conformers.generate_conformers(mol2, max_conformers=2)
     assert mol1.GetNumConformers() > 1
     assert mol2.GetNumConformers() > 1
     _, filename = tempfile.mkstemp(suffix='.sdf')

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -66,7 +66,8 @@ def test_read_file_like():
 def test_read_multiconformer():
     """Read multiconformer SDF file."""
     mol = Chem.MolFromMolBlock(aspirin_sdf)
-    mol = conformers.generate_conformers(mol, max_conformers=2)
+    engine = conformers.ConformerGenerator(max_conformers=2)
+    mol = engine.generate_conformers(mol)
     assert mol.GetNumConformers() > 1
     _, filename = tempfile.mkstemp(suffix='.sdf')
     serial.write_mols_to_file([mol], filename)
@@ -93,10 +94,11 @@ def test_read_multiple_smiles():
 
 def test_read_multiple_multiconformer():
     """Read multiple multiconformer SDF file."""
+    engine = conformers.ConformerGenerator(max_conformers=2)
     mol1 = Chem.MolFromSmiles(aspirin_smiles.split()[0])
-    mol1 = conformers.generate_conformers(mol1, max_conformers=2)
+    mol1 = engine.generate_conformers(mol1)
     mol2 = Chem.MolFromSmiles(ibuprofen_smiles.split()[0])
-    mol2 = conformers.generate_conformers(mol2, max_conformers=2)
+    mol2 = engine.generate_conformers(mol2)
     assert mol1.GetNumConformers() > 1
     assert mol2.GetNumConformers() > 1
     _, filename = tempfile.mkstemp(suffix='.sdf')


### PR DESCRIPTION
The only change in functionality is that now setting `prune_after_minimization` to `False` will also force `pool_multiplier` to 1.
