### PR TITLE
Fix bug where salt remover leaves nothing

### DIFF
--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -351,7 +351,9 @@ class MolReader(MolIO):
             Molecule.
         """
         if self.remove_salts:
-            mol = self.salt_remover.StripMol(mol)
+            new = self.salt_remover.StripMol(mol)
+            if new.GetNumAtoms():
+                mol = new  # the molecule may _be_ a salt
         return mol
 
 

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -440,6 +440,15 @@ class TestMolReader(TestMolIO):
         mols = list(reader.get_mols())
         assert len(mols) == 0
 
+    def test_is_a_salt(self):
+        """
+        Test that a molecule that _is_ a salt is not returned empty.
+        """
+        smiles = 'C(=CC(=O)O)C(=O)O'
+        reader = serial.MolReader(StringIO(smiles), 'smi')
+        mols = list(reader.get_mols())
+        assert len(mols) == 1 and mols[0].GetNumAtoms()
+
 
 class TestMolWriter(TestMolIO):
     """


### PR DESCRIPTION
Fix for a bug where a molecule _is_ a salt and salt removal returns a molecule with zero atoms.
