### PR TITLE
Fix for reading pickled molecules

### DIFF
--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -361,9 +361,12 @@ class MolReader(MolIO):
         """
         if self.remove_salts:
             # hydrogens must be removed for pattern matching to work properly
-            new = self.salt_remover.StripMol(Chem.RemoveHs(mol))
-            if new.GetNumAtoms():
-                mol = new  # the molecule may _be_ a salt
+            mol_no_h = Chem.RemoveHs(mol)
+            new = self.salt_remover.StripMol(mol_no_h)
+            # only keep if it is valid (# the molecule may _be_ a salt) and has
+            # actually been changed
+            if new.GetNumAtoms() and mol_no_h.ToBinary() != new.ToBinary():
+                mol = new
         return mol
 
 

--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -275,10 +275,17 @@ class MolReader(MolIO):
     def _get_mols_from_pickle(self):
         """
         Read pickled molecules from a file-like object.
+
+        Files that contain multiple pickles are supported by repeated calls
+        to load.
         """
-        mols = cPickle.load(self.f)
-        for mol in np.atleast_1d(mols):
-            yield mol
+        while True:
+            try:
+                mols = cPickle.load(self.f)
+                for mol in np.atleast_1d(mols):
+                    yield mol
+            except EOFError:
+                break
 
     def are_same_molecule(self, a, b):
         """

--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -139,7 +139,7 @@ class MolReader(MolIO):
         File-like object.
     mol_format : str, optional
         Molecule file format. Currently supports 'sdf', 'smi', and 'pkl'.
-    remove_hydrogens : bool, optional (default True)
+    remove_hydrogens : bool, optional (default False)
         Remove hydrogens from molecules.
     remove_salts : bool, optional (default True)
         Remove salts from molecules. Note that this will remove any hydrogens
@@ -148,7 +148,7 @@ class MolReader(MolIO):
         Compute 2D coordinates when reading SMILES. If molecules are written to
         SDF without 2D coordinates, stereochemistry information will be lost.
     """
-    def __init__(self, f=None, mol_format=None, remove_hydrogens=True,
+    def __init__(self, f=None, mol_format=None, remove_hydrogens=False,
                  remove_salts=True, compute_2d_coords=True):
         if not remove_hydrogens and remove_salts:
             warnings.warn('Compounds with salts will have hydrogens removed')

--- a/rdkit_utils/serial.py
+++ b/rdkit_utils/serial.py
@@ -139,20 +139,19 @@ class MolReader(MolIO):
         File-like object.
     mol_format : str, optional
         Molecule file format. Currently supports 'sdf', 'smi', and 'pkl'.
-    remove_hydrogens : bool, optional (default False)
+    remove_hydrogens : bool, optional (default True)
         Remove hydrogens from molecules.
-    remove_salts : bool, optional (default False)
+    remove_salts : bool, optional (default True)
         Remove salts from molecules. Note that this will remove any hydrogens
         present on the molecule.
     compute_2d_coords : bool, optional (default True)
         Compute 2D coordinates when reading SMILES. If molecules are written to
         SDF without 2D coordinates, stereochemistry information will be lost.
     """
-    def __init__(self, f=None, mol_format=None, remove_hydrogens=False,
-                 remove_salts=False, compute_2d_coords=True):
+    def __init__(self, f=None, mol_format=None, remove_hydrogens=True,
+                 remove_salts=True, compute_2d_coords=True):
         if not remove_hydrogens and remove_salts:
-            warnings.warn('remove_salts=True forcing remove_hydrogens=True')
-            remove_hydrogens = True
+            warnings.warn('Compounds with salts will have hydrogens removed')
         super(MolReader, self).__init__(f, mol_format)
         self.remove_hydrogens = remove_hydrogens
         self.remove_salts = remove_salts

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -293,7 +293,8 @@ class TestMolReader(TestMolIO):
         assert len(mols) == 1
         # FIXME get ToBinary test to work
         # assert mols[0].ToBinary() == ref_mol.ToBinary()
-        assert Chem.MolToMolBlock(mols[0]) == Chem.MolToMolBlock(ref_mol)
+        assert Chem.MolToMolBlock(mols[0]) == Chem.MolToMolBlock(
+            Chem.RemoveHs(ref_mol))
 
     def test_read_multiple_multiconformer(self):
         """
@@ -328,7 +329,7 @@ class TestMolReader(TestMolIO):
             # assert mol.ToBinary() == ref_mol.ToBinary()
             assert Chem.MolToMolBlock(
                 mol, includeStereo=1) == Chem.MolToMolBlock(
-                    ref_mol, includeStereo=1)
+                    Chem.RemoveHs(ref_mol), includeStereo=1)
 
     def test_are_same_molecule(self):
         """
@@ -345,7 +346,7 @@ class TestMolReader(TestMolIO):
         _, filename = tempfile.mkstemp(suffix='.sdf', dir=self.temp_dir)
         with open(filename, 'wb') as f:
             f.write(Chem.MolToMolBlock(self.aspirin_h))
-        reader = serial.MolReader(remove_hydrogens=False)
+        reader = serial.MolReader(remove_hydrogens=False, remove_salts=False)
         reader.open(filename)
         mols = reader.get_mols()
         # FIXME get ToBinary test to work

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -375,9 +375,9 @@ class TestMolReader(TestMolIO):
                 f.write(Chem.MolToMolBlock(mol))
                 f.write('$$$$\n')  # molecule delimiter
         ref_mols = [self.aspirin_sodium, self.levalbuterol_hcl]
-        reader = serial.MolReader(remove_salts=True)
-        reader.open(filename)
-        mols = reader.get_mols()
+        self.reader = serial.MolReader(remove_salts=True)
+        self.reader.open(filename)
+        mols = self.reader.get_mols()
         mols = list(mols)
         assert len(mols) == 2
         for mol, ref_mol in zip(mols, ref_mols):
@@ -395,11 +395,12 @@ class TestMolReader(TestMolIO):
                 f.write(Chem.MolToMolBlock(mol))
                 f.write('$$$$\n')  # molecule delimiter
         ref_mols = [self.aspirin_sodium, self.levalbuterol_hcl]
-        reader = serial.MolReader(remove_salts=False)
-        reader.open(filename)
-        mols = reader.get_mols()
+        self.reader = serial.MolReader(remove_salts=False)
+        self.reader.open(filename)
+        mols = self.reader.get_mols()
         mols = list(mols)
         assert len(mols) == 2
+        self.reader = serial.MolReader(remove_salts=True)
         for mol, ref_mol in zip(mols, ref_mols):
             assert mol.ToBinary() == ref_mol.ToBinary()
             desalted = self.reader.clean_mol(ref_mol)
@@ -445,7 +446,7 @@ class TestMolReader(TestMolIO):
         Test that a molecule that _is_ a salt is not returned empty.
         """
         smiles = 'C(=CC(=O)O)C(=O)O'
-        reader = serial.MolReader(StringIO(smiles), 'smi')
+        reader = serial.MolReader(StringIO(smiles), 'smi', remove_salts=True)
         mols = list(reader.get_mols())
         assert len(mols) == 1 and mols[0].GetNumAtoms()
 

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -449,6 +449,21 @@ class TestMolReader(TestMolIO):
         mols = list(reader.get_mols())
         assert len(mols) == 1 and mols[0].GetNumAtoms()
 
+    def test_read_multiple_pickles(self):
+        """
+        Test reading a file containing multiple pickles. This can occur if
+        MolWriter.write is called multiple times.
+        """
+        _, filename = tempfile.mkstemp(suffix='.pkl', dir=self.temp_dir)
+        with serial.MolWriter().open(filename) as writer:
+            writer.write([self.aspirin])
+            writer.write([self.levalbuterol])
+        with self.reader.open(filename) as reader:
+            mols = list(reader)
+            assert len(mols) == 2
+            assert mols[0].ToBinary() == self.aspirin.ToBinary()
+            assert mols[1].ToBinary() == self.levalbuterol.ToBinary()
+
 
 class TestMolWriter(TestMolIO):
     """

--- a/rdkit_utils/tests/test_serial.py
+++ b/rdkit_utils/tests/test_serial.py
@@ -293,8 +293,7 @@ class TestMolReader(TestMolIO):
         assert len(mols) == 1
         # FIXME get ToBinary test to work
         # assert mols[0].ToBinary() == ref_mol.ToBinary()
-        assert Chem.MolToMolBlock(mols[0]) == Chem.MolToMolBlock(
-            Chem.RemoveHs(ref_mol))
+        assert Chem.MolToMolBlock(mols[0]) == Chem.MolToMolBlock(ref_mol)
 
     def test_read_multiple_multiconformer(self):
         """
@@ -328,8 +327,8 @@ class TestMolReader(TestMolIO):
             # FIXME get ToBinary test to work
             # assert mol.ToBinary() == ref_mol.ToBinary()
             assert Chem.MolToMolBlock(
-                mol, includeStereo=1) == Chem.MolToMolBlock(
-                    Chem.RemoveHs(ref_mol), includeStereo=1)
+                mol, includeStereo=1) == Chem.MolToMolBlock(ref_mol,
+                                                            includeStereo=1)
 
     def test_are_same_molecule(self):
         """


### PR DESCRIPTION
This PR allows MolReader to correctly read files containing multiple pickles, which can occur if a user makes multiple calls to MolWriter.write when saving in pickle format. Previously, only the first set of pickled molecules in a file was read.
